### PR TITLE
Configurable Image tag. Add debug arg. Use environment arg

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Tye
 {
     public static class ApplicationFactory
     {
-        public static async Task<ApplicationBuilder> CreateAsync(OutputContext output, FileInfo source, string? framework = null, ApplicationFactoryFilter? filter = null)
+        public static async Task<ApplicationBuilder> CreateAsync(OutputContext output, FileInfo source, string? framework = null, ApplicationFactoryFilter? filter = null, string? environment = null)
         {
             if (source is null)
             {
@@ -227,7 +227,9 @@ namespace Microsoft.Tye
 
                         // We don't apply more container defaults here because we might need
                         // to prompt for the registry name.
-                        project.ContainerInfo = new ContainerInfo() { UseMultiphaseDockerfile = false, };
+                        var imageVersion = configService.DockerImageVersion ?? DateTime.UtcNow.ToString("MM\\.dd\\.yyyyHH\\.mm\\.ss\\.fff");
+                        var imageTag = $"{environment}-{imageVersion}";
+                        project.ContainerInfo = new ContainerInfo() { UseMultiphaseDockerfile = false, ImageTag = imageTag };
 
                         // If project evaluation is successful this should not happen, therefore an exception will be thrown.
                         if (!projectMetadata.ContainsKey(configService.Name))

--- a/src/Microsoft.Tye.Core/BuildDockerImageStep.cs
+++ b/src/Microsoft.Tye.Core/BuildDockerImageStep.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Tye

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigFactory.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
-using Microsoft.Tye.Serialization;
 using Tye.DockerCompose;
 using Tye.Serialization;
 

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Tye.ConfigModel
         public string? DockerFile { get; set; }
         public Dictionary<string, string> DockerFileArgs { get; set; } = new Dictionary<string, string>();
         public string? DockerFileContext { get; set; }
+        public string? DockerImageVersion { get; set; }
         public string? Project { get; set; }
         public string? ProjectFullPath { get; set; }
         public string? Include { get; set; }

--- a/src/Microsoft.Tye.Core/DockerContainerBuilder.cs
+++ b/src/Microsoft.Tye.Core/DockerContainerBuilder.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
@@ -59,6 +59,9 @@ namespace Tye.Serialization
                     case "dockerFileContext":
                         service.DockerFileContext = YamlParser.GetScalarValue(key, child.Value);
                         break;
+                    case "dockerImageVersion":
+                        service.DockerImageVersion = YamlParser.GetScalarValue(key, child.Value);
+                        break;
                     case "project":
                         service.Project = YamlParser.GetScalarValue(key, child.Value);
                         break;

--- a/src/tye/StandardOptions.cs
+++ b/src/tye/StandardOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Tye
             {
                 return new Option(new[] { "-e", "--environment" }, "Environment")
                 {
-                    Argument = new Argument<string>("environment", () => "production")
+                    Argument = new Argument<string>("environment", () => "development")
                     {
                         Arity = ArgumentArity.ExactlyOne,
                     },
@@ -66,6 +66,17 @@ namespace Microsoft.Tye
                 return new Option(new[] { "-i", "--interactive", }, "Interactive mode")
                 {
                     Argument = new Argument<bool>(),
+                };
+            }
+        }
+
+        public static Option Debug
+        {
+            get
+            {
+                return new Option(new[] { "-d", "--debug", }, "Debug mode")
+                {
+                    Argument = new Argument<bool>(() => false),
                 };
             }
         }
@@ -221,7 +232,7 @@ namespace Microsoft.Tye
                 {
                     Description = "Specify the namespace for the deployment",
                     Required = false,
-                    Argument = new Argument<string>(),
+                    Argument = new Argument<string>(() => "default"),
                 };
             }
         }


### PR DESCRIPTION
1) Added a `debug` argument (`-d` or -`-debug`) that can be passed to the deploy command that will wait for the debugger to attach to the process before starting.
2) Included the `environment` argument (`-e  or --environment`) in the process instead of just defaulting to "production". The environment is then used when building the image tag for the docker file.
3) Added property to tye.yaml schema for `dockerImageVersion` that can be set on a service. Only using it for our `project` services as of now since that's how we will get everything setup.

The docker image tag will be built like this. `{environment}-{dockerImageVersion}`. If the `dockerImageVersion` isn't set, I am falling back to the current timestamp, which would look like `{environment}-{timeStamp}`