### PR TITLE
Publish/install tye initial research and example

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,9 +5,8 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="penlink-plc" value="https://pkgs.dev.azure.com/PenLinkDevOps/PLC/_packaging/penlink-plc/nuget/v3/index.json" />
   </packageSources>
-  <disabledPackageSources>
+    <disabledPackageSources>
     <clear />
   </disabledPackageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,15 +7,6 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="penlink-plc" value="https://pkgs.dev.azure.com/PenLinkDevOps/PLC/_packaging/penlink-plc/nuget/v3/index.json" />
   </packageSources>
-    <packageSourceCredentials>
-        <penlink-plc>
-            <!-- Username for PAT.  This is the username for the user that generated the PAT. -->
-            <add key="Username" value="dmonk@penlink.com"/>
-            <!-- PAT with Package Read access only.  Expires: 11-13-2023 -->
-            <add key="ClearTextPassword" value="yd6r25pol224dhjeja2354ikvvk3klj74rl2mkh24kkajlp46pja"/>
-            <add key="ValidAuthenticationTypes" value="basic" />
-        </penlink-plc>
-    </packageSourceCredentials>
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,7 +5,17 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="penlink-plc" value="https://pkgs.dev.azure.com/PenLinkDevOps/PLC/_packaging/penlink-plc/nuget/v3/index.json" />
   </packageSources>
+    <packageSourceCredentials>
+        <penlink-plc>
+            <!-- Username for PAT.  This is the username for the user that generated the PAT. -->
+            <add key="Username" value="dmonk@penlink.com"/>
+            <!-- PAT with Package Read access only.  Expires: 11-13-2023 -->
+            <add key="ClearTextPassword" value="yd6r25pol224dhjeja2354ikvvk3klj74rl2mkh24kkajlp46pja"/>
+            <add key="ValidAuthenticationTypes" value="basic" />
+        </penlink-plc>
+    </packageSourceCredentials>
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>

--- a/src/tye/tye.csproj
+++ b/src/tye/tye.csproj
@@ -5,9 +5,11 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Tye</RootNamespace>
     <AssemblyName>tye</AssemblyName>
-    <PackageId>Microsoft.Tye</PackageId>
-    <ToolCommandName>tye</ToolCommandName>
+    <PackageId>PenLink.Tye</PackageId>
+    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <ToolCommandName>ptye</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tye/tye.csproj
+++ b/src/tye/tye.csproj
@@ -6,10 +6,8 @@
     <RootNamespace>Microsoft.Tye</RootNamespace>
     <AssemblyName>tye</AssemblyName>
     <PackageId>PenLink.Tye</PackageId>
-    <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>ptye</ToolCommandName>
-    <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Publish/install tye initial research and example.

My root directory is called 'tye', as such, any references to just the 'tye' directory are referencing this root. All listed commands were run in admin powershell unless explicitely stated otherwise.

Steps to publish/install:
1. Note that I first set the name of the new package in tye.csproj with the PackageId identifier to PenLink.Tye, for clarity. Additionally, I set the name by which we want to call the tool-command to "ptye" with ToolCommandName.
2. In `root/eng/Versions.props` update the `<VersionPrefix>` attribute to the version that you want.
3. From root or just in the directory containing the .csproj you want to publish, you can run
```powershell
dotnet pack
```
This created PenLink.Tye.0.12.4-dev.nupkg in tye\artifacts\packages\Debug\Shipping

4. To publish this to Azure Devops, you will need a package source and credentials. For these, you can open up the NuGet.config file found at %appdata%\NuGet in your file explorer with your favorite code editor and add the following packageSource to it:
```
<add key="penlink-plc" value="https://pkgs.dev.azure.com/PenLinkDevOps/PLC/_packaging/penlink-plc/nuget/v3/index.json" />
```

Then for credentials, to that same file, add the following lines:
```
    <packageSourceCredentials>
        <penlink-plc>
            <!-- Username for PAT.  This is the username for the user that generated the PAT. -->
            <add key="Username" value="<your-login-email>"/>
            <!-- PAT with Package Read access only. -->
            <add key="ClearTextPassword" value="<your-PAT>"/>
            <add key="ValidAuthenticationTypes" value="basic" />
        </penlink-plc>
    </packageSourceCredentials>
```

5. Publish this to Azure Devops with
```powershell
dotnet nuget push --source "penlink-plc" --api-key <api-key> <path to root>\artifacts\packages\Debug\Shipping\PenLink.Tye.0.12.4-dev.nupkg
```
Note that Azure Devops suggests any string will suffice for an API key.

5a. To install from my local package, I ran
```powershell
dotnet tool install --global --add-source <path to root>\artifacts\packages\Debug\Shipping\ PenLink.Tye --version 0.12.4-dev
```
5b. To install the published package from Azure Devops, run
```powershell
dotnet tool install --global Penlink.Tye --version 0.12.4-dev
```

5c. To update the package (you already have ptye installed) run
```powershell
dotnet tool update --global Penlink.Tye --version 0.12.4-dev
```

6. You should now be able to run 'tye' commands using 'ptye' instead, i.e. `ptye run` in lieu of `tye run`.