### PR TITLE
A couple of fixes when deploying with a namespace

### DIFF
--- a/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/DeployApplicationKubernetesManifestStep.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.CommandLine.Invocation;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -79,11 +78,12 @@ namespace Microsoft.Tye
                     };
 
                     var retries = 0;
+                    var namespaceArg = string.IsNullOrEmpty(application.Namespace) ? string.Empty : $"-n {application.Namespace}";
                     while (!done && retries < 60)
                     {
                         var ingressExitCode = await ProcessUtil.ExecuteAsync(
                             "kubectl",
-                            $"get ingress {ingress.Name} -o jsonpath='{{..ip}}'",
+                            $"get ingress {ingress.Name} {namespaceArg} -o jsonpath='{{..ip}}'",
                             Environment.CurrentDirectory,
                             complete,
                             capture.StdErr);

--- a/src/tye/UndeployHost.cs
+++ b/src/tye/UndeployHost.cs
@@ -4,14 +4,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using k8s;
 using k8s.Models;
 using Microsoft.Rest;
-using Microsoft.Tye.ConfigModel;
 
 namespace Microsoft.Tye
 {
@@ -44,7 +42,7 @@ namespace Microsoft.Tye
             var kubernetes = new Kubernetes(config);
 
             // If namespace is null, set it to default
-            config.Namespace ??= "default";
+            config.Namespace ??= @namespace ?? "default";
 
             // Due to some limitations in the k8s SDK we currently have a hardcoded list of resource
             // types that we handle deletes for. If we start adding extensibility for the *kinds* of


### PR DESCRIPTION
What I originally thought was a bug was just me deploying my configurations incorrectly (have to deploy them into each namespace where services are deployed, it's not just one global configuration).

I did notice a couple of little issues though when deploying with namespaces that are adressed here.

1) Use the namespace argument when undeploying. Without this change you can't undeploy from a namespace other than default.
2) Find ingress details in correct namespace. Things would error out when retrieving the ingress details (after it deployed successfully) because it wasn't looking in the right namespace.