### PR TITLE
A handful of fixes and added functionality

### DIFF
--- a/src/Microsoft.Tye.Core/ApplicationExecutor.cs
+++ b/src/Microsoft.Tye.Core/ApplicationExecutor.cs
@@ -27,37 +27,41 @@ namespace Microsoft.Tye
 
         public async Task ExecuteAsync(ApplicationBuilder application)
         {
-            foreach (var service in application.Services)
+            if (ServiceSteps.Count > 0)
             {
-                using var tracker = output.BeginStep($"Processing Service '{service.Name}'...");
-                foreach (var step in ServiceSteps)
+                foreach (var service in application.Services)
                 {
-                    using var stepTracker = output.BeginStep(step.DisplayText);
-                    await step.ExecuteAsync(output, application, service);
-                    stepTracker.MarkComplete();
+                    using var tracker = output.BeginStep($"Processing Service '{service.Name}'...");
+                    foreach (var step in ServiceSteps)
+                    {
+                        using var stepTracker = output.BeginStep(step.DisplayText);
+                        await step.ExecuteAsync(output, application, service);
+                        stepTracker.MarkComplete();
+                    }
+                    tracker.MarkComplete();
                 }
-                tracker.MarkComplete();
             }
 
-            foreach (var ingress in application.Ingress)
+            if (IngressSteps.Count > 0)
             {
-                using var tracker = output.BeginStep($"Processing Ingress '{ingress.Name}'...");
-                foreach (var step in IngressSteps)
+                foreach (var ingress in application.Ingress)
                 {
-                    using var stepTracker = output.BeginStep(step.DisplayText);
-                    await step.ExecuteAsync(output, application, ingress);
-                    stepTracker.MarkComplete();
+                    using var tracker = output.BeginStep($"Processing Ingress '{ingress.Name}'...");
+                    foreach (var step in IngressSteps)
+                    {
+                        using var stepTracker = output.BeginStep(step.DisplayText);
+                        await step.ExecuteAsync(output, application, ingress);
+                        stepTracker.MarkComplete();
+                    }
+                    tracker.MarkComplete();
                 }
-                tracker.MarkComplete();
             }
 
+            foreach (var step in ApplicationSteps)
             {
-                foreach (var step in ApplicationSteps)
-                {
-                    using var stepTracker = output.BeginStep(step.DisplayText);
-                    await step.ExecuteAsync(output, application);
-                    stepTracker.MarkComplete();
-                }
+                using var stepTracker = output.BeginStep(step.DisplayText);
+                await step.ExecuteAsync(output, application);
+                stepTracker.MarkComplete();
             }
         }
 

--- a/src/Microsoft.Tye.Core/ApplicationFactory.cs
+++ b/src/Microsoft.Tye.Core/ApplicationFactory.cs
@@ -227,8 +227,8 @@ namespace Microsoft.Tye
 
                         // We don't apply more container defaults here because we might need
                         // to prompt for the registry name.
-                        var imageVersion = configService.DockerImageVersion ?? DateTime.UtcNow.ToString("MM\\.dd\\.yyyyHH\\.mm\\.ss\\.fff");
-                        var imageTag = $"{environment}-{imageVersion}";
+                        var imageVersion = configService.DockerImageVersion ?? DateTime.UtcNow.ToString("MM\\.dd\\.yyyy\\.HH\\.mm\\.ss");
+                        var imageTag = string.IsNullOrWhiteSpace(environment) ? imageVersion : $"{environment}-{imageVersion}";
                         project.ContainerInfo = new ContainerInfo() { UseMultiphaseDockerfile = false, ImageTag = imageTag };
 
                         // If project evaluation is successful this should not happen, therefore an exception will be thrown.

--- a/src/Microsoft.Tye.Core/ConfigureDockerImageStep.cs
+++ b/src/Microsoft.Tye.Core/ConfigureDockerImageStep.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Tye;
+
+namespace Tye
+{
+    public sealed class ConfigureDockerImageStep : ApplicationExecutor.ServiceStep
+    {
+        public override string DisplayText => "Configuring Docker Image...";
+
+        public override Task ExecuteAsync(OutputContext output, ApplicationBuilder application, ServiceBuilder service)
+        {
+            if (SkipWithoutProject(output, service, out var project))
+            {
+                return Task.CompletedTask;
+            }
+
+            if (SkipWithoutContainerInfo(output, service, out var container))
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!application.ContainerEngine.IsUsable(out string? unusableReason))
+            {
+                throw new CommandException($"Cannot generate a docker image for '{service.Name}' because {unusableReason}.");
+            }
+
+            if (project is DotnetProjectServiceBuilder dotnetProject)
+            {
+                // For configuring the docker image, we have to assume that the images already exist. Just add them to the project.
+                dotnetProject.Outputs.Add(new DockerImageOutput(container.ImageName!, container.ImageTag!));
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.Tye.Core/DockerPush.cs
+++ b/src/Microsoft.Tye.Core/DockerPush.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Tye
 {
     internal static class DockerPush
     {
-        public static async Task ExecuteAsync(OutputContext output, ContainerEngine containerEngine, string imageName, string imageTag, bool includeLatestTag)
+        public static async Task ExecuteAsync(OutputContext output, ContainerEngine containerEngine, string imageName, string imageTag, bool includeLatestTag, string environment)
         {
             if (output is null)
             {
@@ -27,7 +27,7 @@ namespace Microsoft.Tye
             }
 
             var buildImage = $"{imageName}:{imageTag}";
-            var latestImage = includeLatestTag ? $"{imageName}:latest" : string.Empty;
+            var latestImage = includeLatestTag ? $"{imageName}:{environment}-latest" : string.Empty;
 
             if (includeLatestTag)
             {

--- a/src/Microsoft.Tye.Core/GenerateIngressKubernetesManifestStep.cs
+++ b/src/Microsoft.Tye.Core/GenerateIngressKubernetesManifestStep.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Tye
 
         public override async Task ExecuteAsync(OutputContext output, ApplicationBuilder application, IngressBuilder ingress)
         {
-            ingress.Outputs.Add(await KubernetesManifestGenerator.CreateIngress(output, application, ingress));
+            ingress.Outputs.Add(await KubernetesManifestGenerator.CreateIngress(output, application, ingress, Environment));
         }
     }
 }

--- a/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
+++ b/src/Microsoft.Tye.Core/KubernetesManifestGenerator.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Tye
         public static async Task<KubernetesIngressOutput> CreateIngress(
             OutputContext output,
             ApplicationBuilder application,
-            IngressBuilder ingress)
+            IngressBuilder ingress,
+            string environment)
         {
             var root = new YamlMappingNode();
             var k8sVersion = await KubectlDetector.GetKubernetesServerVersion(output);
@@ -125,17 +126,18 @@ namespace Microsoft.Tye
                     // two capture groups.
                     if (string.IsNullOrEmpty(ingressRule.Path) || ingressRule.Path == "/")
                     {
-                        path.Add("path", "/()(.*)"); // () is an empty capture group.
+                        path.Add("path", $"/()({environment}.*)"); // () is an empty capture group.
                     }
                     else
                     {
+                        var pathRoute = ingressRule.Path.StartsWith('/') ? $"/{environment}{ingressRule.Path}" : $"/{environment}/{ingressRule.Path}";
                         if (ingressRule.PreservePath)
                         {
-                            path.Add("path", $"/()({ingressRule.Path.Trim('/')}.*)");
+                            path.Add("path", $"/()({pathRoute.Trim('/')}.*)");
                         }
                         else
                         {
-                            var regex = $"{ingressRule.Path.TrimEnd('/')}(/|$)(.*)";
+                            var regex = $"{pathRoute.TrimEnd('/')}(/|$)(.*)";
                             path.Add("path", regex);
                         }
                     }

--- a/src/Microsoft.Tye.Core/PushDockerImageStep.cs
+++ b/src/Microsoft.Tye.Core/PushDockerImageStep.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Tye
 
         public string Environment { get; set; } = "production";
 
+        public bool IncludeLatestTag { get; set; } = true;
+
         public override async Task ExecuteAsync(OutputContext output, ApplicationBuilder application, ServiceBuilder service)
         {
             if (SkipWithoutProject(output, service, out var _))
@@ -27,7 +29,7 @@ namespace Microsoft.Tye
 
             foreach (var image in service.Outputs.OfType<DockerImageOutput>())
             {
-                await DockerPush.ExecuteAsync(output, application.ContainerEngine, image.ImageName, image.ImageTag);
+                await DockerPush.ExecuteAsync(output, application.ContainerEngine, image.ImageName, image.ImageTag, IncludeLatestTag);
                 output.WriteInfoLine($"Pushed docker image: '{image.ImageName}:{image.ImageTag}'");
             }
         }

--- a/src/Microsoft.Tye.Core/PushDockerImageStep.cs
+++ b/src/Microsoft.Tye.Core/PushDockerImageStep.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Tye
 
             foreach (var image in service.Outputs.OfType<DockerImageOutput>())
             {
-                await DockerPush.ExecuteAsync(output, application.ContainerEngine, image.ImageName, image.ImageTag, IncludeLatestTag);
+                await DockerPush.ExecuteAsync(output, application.ContainerEngine, image.ImageName, image.ImageTag, IncludeLatestTag, Environment);
                 output.WriteInfoLine($"Pushed docker image: '{image.ImageName}:{image.ImageTag}'");
             }
         }

--- a/src/tye/BuildHost.cs
+++ b/src/tye/BuildHost.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -11,15 +9,15 @@ namespace Microsoft.Tye
 {
     public static class BuildHost
     {
-        public static async Task BuildAsync(OutputContext output, FileInfo path, bool interactive, string? framework = null, ApplicationFactoryFilter? filter = null)
+        public static async Task BuildAsync(OutputContext output, FileInfo path, bool interactive, string environment, string? framework = null, ApplicationFactoryFilter? filter = null)
         {
-            var application = await ApplicationFactory.CreateAsync(output, path, framework, filter);
+            var application = await ApplicationFactory.CreateAsync(output, path, framework, filter, environment);
             if (application.Services.Count == 0)
             {
                 throw new CommandException($"No services found in \"{application.Source.Name}\"");
             }
 
-            await ExecuteBuildAsync(output, application, environment: "production", interactive);
+            await ExecuteBuildAsync(output, application, environment, interactive);
         }
 
         public static async Task ExecuteBuildAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive)

--- a/src/tye/GenerateHost.cs
+++ b/src/tye/GenerateHost.cs
@@ -2,18 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.CommandLine;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Tye
 {
     public static class GenerateHost
     {
-        public static async Task GenerateAsync(OutputContext output, FileInfo path, bool interactive, string ns, string? framework = null, ApplicationFactoryFilter? filter = null)
+        public static async Task GenerateAsync(OutputContext output, FileInfo path, bool interactive, string ns, string environment, string? framework = null, ApplicationFactoryFilter? filter = null)
         {
             var application = await ApplicationFactory.CreateAsync(output, path, framework, filter);
 
@@ -25,7 +21,7 @@ namespace Microsoft.Tye
             {
                 application.Namespace = ns;
             }
-            await ExecuteGenerateAsync(output, application, environment: "production", interactive);
+            await ExecuteGenerateAsync(output, application, environment, interactive);
         }
 
         public static async Task ExecuteGenerateAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive)
@@ -46,7 +42,7 @@ namespace Microsoft.Tye
 
                 IngressSteps =
                 {
-                    new GenerateIngressKubernetesManifestStep(),
+                    new GenerateIngressKubernetesManifestStep { Environment = environment, },
                 },
 
                 ApplicationSteps =

--- a/src/tye/Program.BuildCommand.cs
+++ b/src/tye/Program.BuildCommand.cs
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Tye.ConfigModel;
 
 namespace Microsoft.Tye
 {
@@ -24,6 +20,7 @@ namespace Microsoft.Tye
                 StandardOptions.Tags,
                 StandardOptions.Verbosity,
                 StandardOptions.Framework,
+                StandardOptions.Environment,
             };
 
             command.Handler = CommandHandler.Create<BuildCommandArguments>(args =>
@@ -39,7 +36,7 @@ namespace Microsoft.Tye
 
                 var filter = ApplicationFactoryFilter.GetApplicationFactoryFilter(args.Tags);
 
-                return BuildHost.BuildAsync(output, args.Path, args.Interactive, args.Framework, filter);
+                return BuildHost.BuildAsync(output, args.Path, args.Interactive, args.Environment,args.Framework, filter);
             });
 
             return command;
@@ -58,6 +55,8 @@ namespace Microsoft.Tye
             public bool Interactive { get; set; } = false;
 
             public string[] Tags { get; set; } = Array.Empty<string>();
+
+            public string Environment { get; set; } = default!;
         }
     }
 }

--- a/src/tye/Program.BuildPushDeployCommand.cs
+++ b/src/tye/Program.BuildPushDeployCommand.cs
@@ -5,6 +5,7 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -12,22 +13,32 @@ namespace Microsoft.Tye
 {
     static partial class Program
     {
-        public static Command CreatePushCommand()
+        public static Command CreateBuildPushDeployCommand()
         {
-            var command = new Command("push", "build and push application containers to registry")
+            var command = new Command("build-push-deploy", "build, push, and deploy the application")
             {
                 CommonArguments.Path_Required,
                 StandardOptions.Interactive,
                 StandardOptions.Verbosity,
-                StandardOptions.Tags,
+                StandardOptions.Namespace,
                 StandardOptions.Framework,
+                StandardOptions.Tags,
                 StandardOptions.Environment,
                 StandardOptions.IncludeLatestTag,
-                StandardOptions.CreateForce("Override validation and force push.")
+                StandardOptions.Debug,
+                StandardOptions.CreateForce("Override validation and force deployment.")
             };
 
-            command.Handler = CommandHandler.Create<PushCommandArguments>(async args =>
+            command.Handler = CommandHandler.Create<BuildPushDeployCommandArguments>(async args =>
             {
+                if (args.Debug)
+                {
+                    Console.WriteLine("Debug mode is on. Waiting for debugger to attach");
+                    while (!Debugger.IsAttached)
+                        await Task.Delay(100);
+                    Console.WriteLine("Debugger attached");
+                }
+
                 // Workaround for https://github.com/dotnet/command-line-api/issues/723#issuecomment-593062654
                 if (args.Path is null)
                 {
@@ -45,15 +56,32 @@ namespace Microsoft.Tye
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
                 }
 
+                if (!string.IsNullOrEmpty(args.Namespace))
+                {
+                    application.Namespace = args.Namespace;
+                }
+
                 var executeOutput = new OutputContext(args.Console, args.Verbosity);
-                await ExecutePushAsync(output, application, environment: args.Environment, args.Interactive, args.IncludeLatestTag);
+                await ExecuteBuildPushDeployAsync(executeOutput, application, environment: args.Environment, args.Interactive, args.Force, args.IncludeLatestTag);
             });
 
             return command;
         }
 
-        private static async Task ExecutePushAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive, bool includeLatestTag)
+        private static async Task ExecuteBuildPushDeployAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive, bool force, bool includeLatestTag)
         {
+            var watch = Stopwatch.StartNew();
+
+            if (await KubectlDetector.GetKubernetesServerVersion(output) == null)
+            {
+                throw new CommandException($"Cannot apply manifests because kubectl is not installed.");
+            }
+
+            if (!await KubectlDetector.IsKubectlConnectedToClusterAsync(output))
+            {
+                throw new CommandException($"Cannot apply manifests because kubectl is not connected to a cluster.");
+            }
+
             await application.ProcessExtensionsAsync(options: null, output, ExtensionContext.OperationKind.Deploy);
             ApplyRegistry(output, application, interactive, requireRegistry: true);
 
@@ -66,13 +94,32 @@ namespace Microsoft.Tye
                     new PublishProjectStep(),
                     new BuildDockerImageStep() { Environment = environment, },
                     new PushDockerImageStep() { Environment = environment, IncludeLatestTag = includeLatestTag, },
+                    new ValidateSecretStep() { Environment = environment, Interactive = interactive, Force = force, },
+                    new GenerateServiceKubernetesManifestStep() { Environment = environment, },
                 },
+
+                IngressSteps =
+                {
+                    new ValidateIngressStep() { Environment = environment, Interactive = interactive, Force = force, },
+                    new GenerateIngressKubernetesManifestStep { Environment = environment, },
+                },
+
+                ApplicationSteps =
+                {
+                    new DeployApplicationKubernetesManifestStep(),
+                }
             };
 
             await executor.ExecuteAsync(application);
+
+            watch.Stop();
+
+            TimeSpan elapsedTime = watch.Elapsed;
+
+            output.WriteAlwaysLine($"Time Elapsed: {elapsedTime.Hours:00}:{elapsedTime.Minutes:00}:{elapsedTime.Seconds:00}:{elapsedTime.Milliseconds / 10:00}");
         }
 
-        private class PushCommandArguments
+        private class BuildPushDeployCommandArguments
         {
             public IConsole Console { get; set; } = default!;
 
@@ -80,15 +127,21 @@ namespace Microsoft.Tye
 
             public Verbosity Verbosity { get; set; }
 
+            public string Namespace { get; set; } = default!;
+
             public bool Interactive { get; set; } = false;
 
             public string Framework { get; set; } = default!;
+
+            public bool Force { get; set; } = false;
 
             public string[] Tags { get; set; } = Array.Empty<string>();
 
             public string Environment { get; set; } = default!;
 
             public bool IncludeLatestTag { get; set; } = true;
+
+            public bool Debug { get; set; } = false;
         }
     }
 }

--- a/src/tye/Program.DeployCommand.cs
+++ b/src/tye/Program.DeployCommand.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Tye
                 StandardOptions.Framework,
                 StandardOptions.Tags,
                 StandardOptions.Environment,
-                StandardOptions.IncludeLatestTag,
                 StandardOptions.Debug,
                 StandardOptions.CreateForce("Override validation and force deployment.")
             };
@@ -63,13 +62,13 @@ namespace Microsoft.Tye
                 }
 
                 var executeOutput = new OutputContext(args.Console, args.Verbosity);
-                await ExecuteDeployAsync(executeOutput, application, environment: args.Environment, args.Interactive, args.Force, args.IncludeLatestTag);
+                await ExecuteDeployAsync(executeOutput, application, environment: args.Environment, args.Interactive, args.Force);
             });
 
             return command;
         }
 
-        private static async Task ExecuteDeployAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive, bool force, bool includeLatestTag)
+        private static async Task ExecuteDeployAsync(OutputContext output, ApplicationBuilder application, string environment, bool interactive, bool force)
         {
             var watch = System.Diagnostics.Stopwatch.StartNew();
 
@@ -157,8 +156,6 @@ namespace Microsoft.Tye
             public string[] Tags { get; set; } = Array.Empty<string>();
 
             public string Environment { get; set; } = default!;
-
-            public bool IncludeLatestTag { get; set; } = true;
 
             public bool Debug { get; set; } = false;
         }

--- a/src/tye/Program.GenerateCommand.cs
+++ b/src/tye/Program.GenerateCommand.cs
@@ -3,13 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Tye.ConfigModel;
 
 namespace Microsoft.Tye
 {
@@ -25,6 +21,7 @@ namespace Microsoft.Tye
                 StandardOptions.Namespace,
                 StandardOptions.Tags,
                 StandardOptions.Framework,
+                StandardOptions.Environment,
             };
 
             // This is a super-secret VIP-only command! It's useful for testing, but we're 
@@ -44,7 +41,7 @@ namespace Microsoft.Tye
 
                 var filter = ApplicationFactoryFilter.GetApplicationFactoryFilter(args.Tags);
 
-                return GenerateHost.GenerateAsync(output, args.Path, args.Interactive, args.Namespace, args.Framework, filter);
+                return GenerateHost.GenerateAsync(output, args.Path, args.Interactive, args.Namespace, args.Environment, args.Framework, filter);
             });
 
             return command;
@@ -63,6 +60,8 @@ namespace Microsoft.Tye
             public string Namespace { get; set; } = default!;
 
             public string Framework { get; set; } = default!;
+
+            public string Environment { get; set; } = default!;
 
             public string[] Tags { get; set; } = Array.Empty<string>();
         }

--- a/src/tye/Program.cs
+++ b/src/tye/Program.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Tye
             command.AddCommand(CreateBuildCommand());
             command.AddCommand(CreatePushCommand());
             command.AddCommand(CreateDeployCommand());
+            command.AddCommand(CreateBuildPushDeployCommand());
             command.AddCommand(CreateUndeployCommand());
 
             // Show commandline help unless a subcommand was used.

--- a/src/tye/StandardOptions.cs
+++ b/src/tye/StandardOptions.cs
@@ -81,6 +81,17 @@ namespace Microsoft.Tye
             }
         }
 
+        public static Option IncludeLatestTag
+        {
+            get
+            {
+                return new Option(new[] { "--include-latest-tag", }, "Push a docker image with 'latest' tag as well as versioned tag")
+                {
+                    Argument = new Argument<bool>(() => true),
+                };
+            }
+        }
+
         public static Option Outputs
         {
             get


### PR DESCRIPTION
- Add option to also tag a `latest` image when pushing images. Default this to true, but went back and forth on the default and could easily be convinced to go false.
- Updated `deploy` command to only deploy to kubernetes. It no longer will build or push the images. It will assume the that the configured image name and tag have already been pushed to the registry
- Add a `build-push-deploy` command that just has the same functionality that `deploy` used to have.
- Added the environment to the ingress path. I wasn't able to do multiple deployments to separate namespaces because there would be multiple ingresses with the same path. 
- Quiet some logging that is confusing when iterating through steps when there are no steps.
- Pass `environment` arg through in some other spots that make sense/we may use

It feels like things might be starting to get a little specific to PenLink as a public repo, but I think all of the things added/changed here still make sense for general best practices for the most part. Let me know your thoughts.