### PR TITLE
Update configurations to support our decided up naming scheme for image tags

### DIFF
--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigApplication.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigApplication.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Tye.ConfigModel
 
         public string? Network { get; set; }
 
+        /// <summary>
+        /// This version will be used in the tagged docker images. Can be overriden at the service level.
+        /// </summary>
+        public string? MainImageVersion { get; set; }
+
         public List<Dictionary<string, object>> Extensions { get; set; } = new List<Dictionary<string, object>>();
 
         public List<ConfigService> Services { get; set; } = new List<ConfigService>();

--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigService.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Tye.ConfigModel
         public string? DockerFile { get; set; }
         public Dictionary<string, string> DockerFileArgs { get; set; } = new Dictionary<string, string>();
         public string? DockerFileContext { get; set; }
-        public string? DockerImageVersion { get; set; }
         public string? Project { get; set; }
         public string? ProjectFullPath { get; set; }
         public string? Include { get; set; }
@@ -47,5 +46,15 @@ namespace Microsoft.Tye.ConfigModel
         public string? Version { get; set; }
         public string? Architecture { get; set; }
         public string? CloneDirectory { get; internal set; }
+
+        /// <summary>
+        /// This version will be used in the tag of images. This will be prioritized over <see cref="ConfigApplication.MainImageVersion"/>.
+        /// </summary>
+        public string? MainImageVersion { get; set; }
+
+        /// <summary>
+        /// Name of the docker image. Ignored when <see cref="Project"/> is <c>null</c>. 
+        /// </summary>
+        public string? ProjectImageName { get; set; }
     }
 }

--- a/src/Microsoft.Tye.Core/Serialization/ConfigApplicationParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigApplicationParser.cs
@@ -58,6 +58,9 @@ namespace Tye.Serialization
                             throw new TyeYamlException(child.Key.Start, CoreStrings.FormatMustBeAnInteger(key));
                         }
                         break;
+                    case "mainImageVersion":
+                        app.MainImageVersion = YamlParser.GetScalarValue(key, child.Value);
+                        break;
                     case "ingress":
                         YamlParser.ThrowIfNotYamlSequence(key, child.Value);
                         ConfigIngressParser.HandleIngress((child.Value as YamlSequenceNode)!, app.Ingress);

--- a/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
+++ b/src/Microsoft.Tye.Core/Serialization/ConfigServiceParser.cs
@@ -59,9 +59,6 @@ namespace Tye.Serialization
                     case "dockerFileContext":
                         service.DockerFileContext = YamlParser.GetScalarValue(key, child.Value);
                         break;
-                    case "dockerImageVersion":
-                        service.DockerImageVersion = YamlParser.GetScalarValue(key, child.Value);
-                        break;
                     case "project":
                         service.Project = YamlParser.GetScalarValue(key, child.Value);
                         break;
@@ -166,6 +163,12 @@ namespace Tye.Serialization
                         break;
                     case "cloneDirectory":
                         service.CloneDirectory = YamlParser.GetScalarValue(key, child.Value);
+                        break;
+                    case "mainImageVersion":
+                        service.MainImageVersion = YamlParser.GetScalarValue(key, child.Value);
+                        break;
+                    case "projectImageName":
+                        service.ProjectImageName = YamlParser.GetScalarValue(key, child.Value);
                         break;
                     default:
                         throw new TyeYamlException(child.Key.Start, CoreStrings.FormatUnrecognizedKey(key));

--- a/src/tye/BuildHost.cs
+++ b/src/tye/BuildHost.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Tye
 {
     public static class BuildHost
     {
-        public static async Task BuildAsync(OutputContext output, FileInfo path, bool interactive, string environment, string? framework = null, ApplicationFactoryFilter? filter = null)
+        public static async Task BuildAsync(OutputContext output, FileInfo path, bool interactive, string environment, string? buildId, string? framework = null, ApplicationFactoryFilter? filter = null)
         {
-            var application = await ApplicationFactory.CreateAsync(output, path, framework, filter, environment);
+            var application = await ApplicationFactory.CreateAsync(output, path, framework, filter, environment, buildId);
             if (application.Services.Count == 0)
             {
                 throw new CommandException($"No services found in \"{application.Source.Name}\"");

--- a/src/tye/Program.BuildCommand.cs
+++ b/src/tye/Program.BuildCommand.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Tye
                 StandardOptions.Verbosity,
                 StandardOptions.Framework,
                 StandardOptions.Environment,
+                StandardOptions.BuildId,
             };
 
             command.Handler = CommandHandler.Create<BuildCommandArguments>(args =>
@@ -36,7 +37,7 @@ namespace Microsoft.Tye
 
                 var filter = ApplicationFactoryFilter.GetApplicationFactoryFilter(args.Tags);
 
-                return BuildHost.BuildAsync(output, args.Path, args.Interactive, args.Environment,args.Framework, filter);
+                return BuildHost.BuildAsync(output, args.Path, args.Interactive, args.Environment, args.BuildId, args.Framework, filter);
             });
 
             return command;
@@ -57,6 +58,8 @@ namespace Microsoft.Tye
             public string[] Tags { get; set; } = Array.Empty<string>();
 
             public string Environment { get; set; } = default!;
+
+            public string? BuildId { get; set; }
         }
     }
 }

--- a/src/tye/Program.BuildPushDeployCommand.cs
+++ b/src/tye/Program.BuildPushDeployCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Tye
                 StandardOptions.Tags,
                 StandardOptions.Environment,
                 StandardOptions.IncludeLatestTag,
+                StandardOptions.BuildId,
                 StandardOptions.Debug,
                 StandardOptions.CreateForce("Override validation and force deployment.")
             };
@@ -50,7 +51,7 @@ namespace Microsoft.Tye
 
                 var filter = ApplicationFactoryFilter.GetApplicationFactoryFilter(args.Tags);
 
-                var application = await ApplicationFactory.CreateAsync(output, args.Path, args.Framework, filter, args.Environment);
+                var application = await ApplicationFactory.CreateAsync(output, args.Path, args.Framework, filter, args.Environment, args.BuildId);
                 if (application.Services.Count == 0)
                 {
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
@@ -140,6 +141,8 @@ namespace Microsoft.Tye
             public string Environment { get; set; } = default!;
 
             public bool IncludeLatestTag { get; set; } = true;
+
+            public string? BuildId { get; set; }
 
             public bool Debug { get; set; } = false;
         }

--- a/src/tye/Program.DeployCommand.cs
+++ b/src/tye/Program.DeployCommand.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Tye
                 StandardOptions.Tags,
                 StandardOptions.Environment,
                 StandardOptions.Debug,
+                StandardOptions.BuildId,
                 StandardOptions.CreateForce("Override validation and force deployment.")
             };
 
@@ -50,7 +51,7 @@ namespace Microsoft.Tye
 
                 var filter = ApplicationFactoryFilter.GetApplicationFactoryFilter(args.Tags);
 
-                var application = await ApplicationFactory.CreateAsync(output, args.Path, args.Framework, filter, args.Environment);
+                var application = await ApplicationFactory.CreateAsync(output, args.Path, args.Framework, filter, args.Environment, args.BuildId);
                 if (application.Services.Count == 0)
                 {
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
@@ -156,6 +157,8 @@ namespace Microsoft.Tye
             public string[] Tags { get; set; } = Array.Empty<string>();
 
             public string Environment { get; set; } = default!;
+
+            public string? BuildId { get; set; }
 
             public bool Debug { get; set; } = false;
         }

--- a/src/tye/Program.PushCommand.cs
+++ b/src/tye/Program.PushCommand.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Tye
                 StandardOptions.Framework,
                 StandardOptions.Environment,
                 StandardOptions.IncludeLatestTag,
+                StandardOptions.BuildId,
                 StandardOptions.CreateForce("Override validation and force push.")
             };
 
@@ -39,7 +40,7 @@ namespace Microsoft.Tye
 
                 var filter = ApplicationFactoryFilter.GetApplicationFactoryFilter(args.Tags);
 
-                var application = await ApplicationFactory.CreateAsync(output, args.Path, args.Framework, filter, args.Environment);
+                var application = await ApplicationFactory.CreateAsync(output, args.Path, args.Framework, filter, args.Environment, args.BuildId);
                 if (application.Services.Count == 0)
                 {
                     throw new CommandException($"No services found in \"{application.Source.Name}\"");
@@ -89,6 +90,8 @@ namespace Microsoft.Tye
             public string Environment { get; set; } = default!;
 
             public bool IncludeLatestTag { get; set; } = true;
+
+            public string? BuildId { get; set; }
         }
     }
 }

--- a/src/tye/StandardOptions.cs
+++ b/src/tye/StandardOptions.cs
@@ -92,6 +92,17 @@ namespace Microsoft.Tye
             }
         }
 
+        public static Option BuildId
+        {
+            get
+            {
+                return new Option(new[] { "-b", "--build-id" }, "Build ID. Used for uniquely naming image tags.")
+                {
+                    Argument = new Argument<string?>(),
+                };
+            }
+        }
+
         public static Option Outputs
         {
             get


### PR DESCRIPTION
- New application wide configuration `mainImageVersion`. This is the v1.0 that we talked about going in our image tag
- New service configuration `mainImageVersion`. This will override the application wide config when it is set on the service. If not set it will use the app wide config. If neither are set, it won't be used in the tag.
- New service configuration `projectImageName`. This is the name of the image. Beforeit just used the name of the service.
- Got rid of the `dockerImageVersion` that I hastily added last week as that's just not really what we need.
- New command line arg for build ID added to `build`, `push`, `deploy`, and `build-push-deploy`. This will be used in the tag as well. If none is provided, we fall back to the current UTC timestamp so we still get some uniqueness.