### PR TITLE
Dapr NAMESPACE

### DIFF
--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtension.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Tye.Extensions.Dapr
                     var daprExecutablePath = GetDaprExecutablePath();
 
                     string appId = serviceConfiguration?.AppId ?? project.Name;
+                    string? daprNamespace = serviceConfiguration?.Namespace ?? extensionConfiguration?.Namespace;
 
                     var proxy = new ExecutableServiceBuilder($"{project.Name}-dapr", daprExecutablePath, ServiceSource.Extension)
                     {
@@ -196,6 +197,14 @@ namespace Microsoft.Tye.Extensions.Dapr
                     };
                     proxy.Bindings.Add(metrics);
 
+                    if (!string.IsNullOrEmpty(daprNamespace))
+                    {
+                        var ns = new EnvironmentVariableBuilder("NAMESPACE")
+                        {
+                            Value = daprNamespace,
+                        };
+                        proxy.EnvironmentVariables.Add(ns);
+                    }
                     if (httpBinding != null)
                     {
                         // Set APP_PORT based on the project's assigned port for http

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfiguration.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfiguration.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Tye.Extensions.Dapr
         public bool? EnableProfiling { get; set; }
         public int? HttpMaxRequestSize { get; set; }
         public string? LogLevel { get; set; }
+        public string? Namespace { get; set; }
         public int? PlacementPort { get; set; }
     }
 

--- a/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfigurationReader.cs
+++ b/src/Microsoft.Tye.Extensions/Dapr/DaprExtensionConfigurationReader.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Tye.Extensions.Dapr
             commonConfiguration.EnableProfiling = TryGetValue<bool>(rawConfiguration, "enable-profiling");
             commonConfiguration.HttpMaxRequestSize = TryGetValue<int>(rawConfiguration, "http-max-request-size");
             commonConfiguration.LogLevel = TryGetValue(rawConfiguration, "log-level");
+            commonConfiguration.Namespace = TryGetValue(rawConfiguration, "namespace");
             commonConfiguration.PlacementPort = TryGetValue<int>(rawConfiguration, "placement-port");
         }
 


### PR DESCRIPTION
Adding support for dapr namespace environment variable.  This probably is something that we could cherry pick over to get into regular Tye if we wanted.

This namespace is only used in conjunction with proper handling of the namespaced components in self-hosted mode (i.e., load the ones in the same namespace.  So in the end it doesn't not actually do much for us.

My real issue I believe is that mDNS does not support namespaces, it will strip them it appears.  So in order to do local dev in which we may want to have multiple services of the same type running we need to address them a little different.

I'm going back and forth a bit on that, not sure there is a benefit or need then if namespaces aren't working to having the multiple, say subscription access services, running.  Just have no namespaces in local dev really.

Either way though supporting this makes sense in general for Tye.