### PR TITLE
Empty Environment Variables

### DIFF
--- a/src/Microsoft.Tye.Core/ConfigModel/ConfigConfigurationSource.cs
+++ b/src/Microsoft.Tye.Core/ConfigModel/ConfigConfigurationSource.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Tye.ConfigModel
         [Required]
         public string Name { get; set; } = default!;
 
-        [Required]
+        [Required(AllowEmptyStrings = true)]
         public string Value { get; set; } = default!;
     }
 }


### PR DESCRIPTION
OS's support empty strings for environment variables from what I can tell.  Subsequently this allows for explicitly ensuring an environment variables is set to nothing.